### PR TITLE
Fixing dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require": {
     	"php": ">=7.0.0",
         "mouf/security.userservice": "^2.1.0",
-        "mouf/mvc.splash-common": "^8.0.0"
+        "mouf/mvc.splash-common": "^8.0.0",
+        "mouf/security.simplelogincontroller": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Logged.php
+++ b/src/Logged.php
@@ -51,7 +51,7 @@ class Logged
     {
         $middlewareName = $container->get($this->middlewareName);
 
-        $response = $middlewareName($request, $response, $next);
+        $response = $middlewareName($request, $response, $next, $container);
 
         return $response;
     }

--- a/src/UnauthorizedMiddleware.php
+++ b/src/UnauthorizedMiddleware.php
@@ -30,6 +30,7 @@ class UnauthorizedMiddleware
     public function __construct(UserServiceInterface $userService, LoginController $loginController)
     {
         $this->userService = $userService;
+        $this->loginController = $loginController;
     }
 
     /**

--- a/src/UnauthorizedMiddlewareInstaller.php
+++ b/src/UnauthorizedMiddlewareInstaller.php
@@ -33,7 +33,7 @@ class UnauthorizedMiddlewareInstaller implements PackageInstallerInterface
         $simpleLoginController = $moufManager->getInstanceDescriptor('simpleLoginController');
 
         // Let's create the instances.
-        $unauthorizedMiddleWare = InstallUtils::getOrCreateInstance('unauthorizedMiddleWare', 'Mouf\\Security\\UnauthorizedMidleware', $moufManager);
+        $unauthorizedMiddleWare = InstallUtils::getOrCreateInstance('unauthorizedMiddleWare', 'Mouf\\Security\\UnauthorizedMiddleware', $moufManager);
 
         // Let's bind instances together.
         if (!$unauthorizedMiddleWare->getConstructorArgumentProperty('userService')->isValueSet()) {

--- a/src/UnauthorizedMiddlewareInstaller.php
+++ b/src/UnauthorizedMiddlewareInstaller.php
@@ -33,7 +33,7 @@ class UnauthorizedMiddlewareInstaller implements PackageInstallerInterface
         $simpleLoginController = $moufManager->getInstanceDescriptor('simpleLoginController');
 
         // Let's create the instances.
-        $unauthorizedMiddleWare = InstallUtils::getOrCreateInstance('unauthorizedMiddleWare', 'Mouf\\Security\\UnauthorizedMiddleware', $moufManager);
+        $unauthorizedMiddleWare = InstallUtils::getOrCreateInstance('Mouf\\Security\\UnauthorizedMiddleware', 'Mouf\\Security\\UnauthorizedMiddleware', $moufManager);
 
         // Let's bind instances together.
         if (!$unauthorizedMiddleWare->getConstructorArgumentProperty('userService')->isValueSet()) {


### PR DESCRIPTION
To install the unauthorized middleware, we need to have a simplelogincontroller instance available first. Otherwise, Mouf install fails.
