### PR TITLE
Remove the package renderer of simpleLoginController because this pac…

### DIFF
--- a/src/UnauthorizedMiddlewareInstaller.php
+++ b/src/UnauthorizedMiddlewareInstaller.php
@@ -24,8 +24,6 @@ class UnauthorizedMiddlewareInstaller implements PackageInstallerInterface
      */
     public static function install(MoufManager $moufManager)
     {
-        RendererUtils::createPackageRenderer($moufManager, 'mouf/security.simplelogincontroller');
-
         $moufManager = MoufManager::getMoufManager();
 
         // These instances are expected to exist when the installer is run.


### PR DESCRIPTION
…kage doesn't depends of it.

This function is in the simpleLogController installer
